### PR TITLE
fix: 维护仓失去控制器时跳过维护计算（#1755）

### DIFF
--- a/src/main/java/com/gtocore/integration/jade/provider/MaintenanceParamProvider.java
+++ b/src/main/java/com/gtocore/integration/jade/provider/MaintenanceParamProvider.java
@@ -89,7 +89,9 @@ public class MaintenanceParamProvider extends CapabilityBlockProvider<IMaintenan
     }
 
     static float getDamageMultiplier(IMaintenanceMachine machine) {
-        int pa = machine.getController().getParts().length;
+        var controller = machine.getController();
+        // write() already skips when null; keep defensive for other callers.
+        int pa = controller == null || controller.getParts() == null ? 1 : Math.max(1, controller.getParts().length);
         return machine.getTimeMultiplier() * GTOCore.difficulty * pa;
     }
 

--- a/src/main/java/com/gtocore/mixin/gtm/machine/MaintenanceHatchPartMachineMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtm/machine/MaintenanceHatchPartMachineMixin.java
@@ -72,7 +72,12 @@ public abstract class MaintenanceHatchPartMachineMixin extends WorkableTieredPar
     @Override
     public void calculateMaintenance(IMaintenanceMachine maintenanceMachine, int duration) {
         if (maintenanceMachine.isFullAuto()) return;
-        var pa = getController().getParts().length;
+        // Structure may unform mid-recipe; getController() can be null (issue #1755).
+        var controller = getController();
+        if (controller == null) return;
+        var parts = controller.getParts();
+        if (parts == null || parts.length == 0) return;
+        var pa = parts.length;
         timeActive = MathUtil.saturatedCast((long) (timeActive + (duration * getTimeMultiplier() * GTOCore.difficulty * pa)));
         var value = ((float) timeActive / MINIMUM_MAINTENANCE_TIME) - 0.7;
         if (GTValues.RNG.nextFloat() <= value && !GTOCore.isEasy()) {


### PR DESCRIPTION
## 摘要
修复 [GregTech-Odyssey#1755](https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1755)：多方块解体/维护仓失去控制器后，`calculateMaintenance` 对 `getController()` 空指针崩溃。

## 根因
`MaintenanceHatchPartMachineMixin.calculateMaintenance` 无条件调用：

`java
getController().getParts().length
`

配方结束 `afterWorking` 触发维护计算时，结构可能已解绑，`getController()` 为 null。

## 改动
- **`MaintenanceHatchPartMachineMixin`**：`controller == null` 或 `parts` 为空时直接 return，跳过本轮维护累计
- **`MaintenanceParamProvider`**：损坏倍率计算防御 null 控制器（`write` 侧本已有判断，补齐工具方法）

## 测试计划
- [ ] 多方块运行中拆除维护仓或破坏结构，服务端不崩溃
- [ ] 正常成型多方块仍会按难度/部件数累计维护问题
- [ ] Jade 维护参数在正常/未成型时不 NPE