### PR TITLE
ci: require explicit PR build command and owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# GitHub cannot target the Organization Owner role dynamically. Keep this list
+# synchronized with the current GregTech-Odyssey organization owners.
+/.github/workflows/** @gjmhmm8 @Hophenby @nutant233 @Ricky-fight @snylonue @wanggugu197 @xinxinsuried
+
+# Keep ownership changes under the same approval boundary.
+/.github/CODEOWNERS @gjmhmm8 @Hophenby @nutant233 @Ricky-fight @snylonue @wanggugu197 @xinxinsuried

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,12 @@ name: "Build and Sign"
 # 1) push：commit message 含 -b / --build / -build
 # 2) pull_request_target opened：PR 由组织成员提起 → 自动构建一次（无需标记）
 # 3) pull_request_target synchronize：最新 head commit 含构建标记才构建
-# 4) issue_comment：组织成员在 PR 下评论含 -b / --build / -build → 构建 PR head
+# 4) issue_comment：组织成员在 PR 下评论，且第一行精确为 /build → 构建 PR head
 #
 # 使用 pull_request_target（而非 pull_request）以便 fork 来源的 PR 也能使用
 # 本仓/组织 secrets 签名。工作流文件始终取 base 分支，降低被 PR 篡改 workflow 的风险。
 # 安全：仅组织成员（或写权限 collaborator）可通过上述路径触发；构建仍会执行 PR 代码，
-# 成员在外部贡献上评论 --build 即表示已审阅并愿意签名构建。
+# 成员在外部贡献上评论 /build 即表示已审阅并愿意签名构建。
 on:
   push:
   pull_request_target:
@@ -44,11 +44,7 @@ jobs:
         (
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
-          (
-            contains(github.event.comment.body, '--build') ||
-            contains(github.event.comment.body, '-build') ||
-            contains(github.event.comment.body, '-b')
-          )
+          startsWith(github.event.comment.body, '/build')
         )
       )
     runs-on: ubuntu-latest
@@ -90,11 +86,14 @@ jobs:
 
           has_build_marker() {
             local msg="$1"
-            [[ "$msg" == *'--build'* ]] && return 0
-            [[ "$msg" == *'-build'* ]] && return 0
-            [[ "$msg" == *' -b'* ]] && return 0
-            [[ "$msg" == '-b' || "$msg" == '-b '* || "$msg" == *'-b' ]] && return 0
-            return 1
+            [[ "$msg" =~ (^|[[:space:]])(--build|-build|-b)($|[[:space:]]) ]]
+          }
+
+          has_pr_build_command() {
+            local first_line
+            IFS= read -r first_line <<< "$1"
+            first_line="${first_line%$'\r'}"
+            [[ "$first_line" == '/build' ]]
           }
 
           # 返回 0=成员/写权限；1=明确拒绝（bot）；2=非成员
@@ -228,10 +227,10 @@ jobs:
               if [ "$IS_PR_COMMENT" != "true" ]; then
                 skip "comment is not on a pull request"
               fi
-              if ! has_build_marker "$COMMENT_BODY"; then
-                skip "PR comment without build marker"
+              if ! has_pr_build_command "$COMMENT_BODY"; then
+                skip "PR comment first line is not exactly /build"
               fi
-              # 评论触发：评论者须为组织成员；非成员评论 --build soft skip
+              # 评论触发：评论者须为组织成员；非成员评论 /build soft skip
               CHECK_USER="${COMMENT_USER:-$ACTOR}"
               OUT_PR="$PR_NUMBER"
               PR_JSON=$(curl -sS "${HDR[@]}" "${API}/repos/${REPO}/pulls/${PR_NUMBER}")
@@ -239,7 +238,7 @@ jobs:
               CHECKOUT_REF=$(python3 -c "import json,sys; print(json.load(sys.stdin)['head']['sha'])" <<<"$PR_JSON")
               HEAD_REF=$(python3 -c "import json,sys; print(json.load(sys.stdin)['head']['ref'])" <<<"$PR_JSON")
               echo "PR #${PR_NUMBER} comment by @${CHECK_USER} → build ${CHECKOUT_REPO}@${CHECKOUT_REF} (${HEAD_REF})"
-              REASON="PR comment build marker by org member"
+              REASON="PR /build command by org member"
               MEMBER_MODE="soft"
               ;;
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,19 +14,19 @@
 
 触发 **Build and Sign** 云端工作流：
 
-| 触发 | 条件 | 是否需要 `--build` / `-build` / `-b` |
-|------|------|--------------------------------------|
+| 触发 | 条件 | 所需标记 / 命令 |
+|------|------|-----------------|
 | `push` | commit message 含构建标记（单独成词，如 `release --build`） | **需要** |
 | PR **opened** | 提起人为**组织成员** → 自动构建一次（按 PR head） | **不需要** |
 | PR **synchronize**（新提交） | head commit 含构建标记，且推送者为组织成员 | **需要** |
-| PR **评论** | 组织成员在 PR 下评论含 `-b` / `--build` / `-build` | 评论中带标记 |
+| PR **评论** | 组织成员在 PR 下评论，第一行必须精确为 `/build` | `/build` |
 
 - 产出**签名版** jar——只有这个版本可以放进整合包使用。
 - 仅**组织成员**（或本仓 write 级 collaborator）能触发签名构建；bot 与外部人员会被拒绝。
 - **本地构建的 jar 未经签名，无法放进整合包**；本地构建只用于开发调试（runClient 等）。
-- **外部 fork PR**：工作流使用 `pull_request_target`，在 base 仓上下文运行，**可以**使用 org secrets 签名。外部贡献者开 PR 不会自动构建；组织成员审阅后在 PR 下评论 `--build`（或 `-b`）即可触发对 **PR head（含 fork）** 的签名构建。
+- **外部 fork PR**：工作流使用 `pull_request_target`，在 base 仓上下文运行，**可以**使用 org secrets 签名。外部贡献者开 PR 不会自动构建；组织成员审阅后在 PR 下以 `/build` 作为第一行评论，即可触发对 **PR head（含 fork）** 的签名构建。
 - **PR 状态反馈**：构建开始时会在 PR 下发一条 bot 评论（⏳ 正在构建 + Actions 链接）；完成/失败/取消后会**原地更新**同一条评论。`issue_comment` 触发的 run **不会**出现在 PR Checks 页，请看这条评论或 [Actions](https://github.com/GregTech-Odyssey/GTOCore-Main/actions)。
-- **安全**：`pull_request_target` 会执行 PR 侧代码（`build.gradle` 等）并注入签名 secrets。成员评论 `--build` 即表示已审阅并愿意签名；勿对未审代码轻易触发。
+- **安全**：`pull_request_target` 会执行 PR 侧代码（`build.gradle` 等）并注入签名 secrets。成员评论 `/build` 即表示已审阅并愿意签名；勿对未审代码轻易触发。
 
 ## 分支与 gtolib 预构建
 


### PR DESCRIPTION
## Summary
- require `/build` as the exact first line for PR comment-triggered signed builds
- keep commit build markers as standalone tokens
- add CODEOWNERS for GitHub Actions workflows and the ownership file itself
- document the updated trigger contract

## Validation
- YAML lint passed
- build-marker shell cases passed
- `git diff --check` passed

The repository ruleset already has required code-owner review enabled.