### PR TITLE
fix: ME输入仓流体 Ctrl+滚轮上滚翻倍失效

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/widget/slot/AEFluidConfigSlotWidget.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/widget/slot/AEFluidConfigSlotWidget.java
@@ -258,7 +258,7 @@ public class AEFluidConfigSlotWidget extends AEConfigSlotWidget implements IGhos
                 FluidStack.EMPTY;
         long amt;
         if (isCtrlDown()) {
-            amt = wheelDelta > 0 ? fluid.getAmount() : fluid.getAmount() / 2L;
+            amt = wheelDelta > 0 ? fluid.getAmount() * 2L : fluid.getAmount() / 2L;
         } else {
             amt = wheelDelta > 0 ? fluid.getAmount() + 1L : fluid.getAmount() - 1L;
         }


### PR DESCRIPTION
## 问题

GregTech-Odyssey/GregTech-Odyssey#1791:ME 输入仓(流体)按住 Ctrl+滚轮上滚"数量翻倍"无效,下滚"减半"正常;ME 输入总线(物品)两个方向均正常。

## 原因

`AEFluidConfigSlotWidget.mouseWheelMove()` 中 Ctrl+上滚分支把数量设成了原值本身,漏乘 2:

```java
amt = wheelDelta > 0 ? fluid.getAmount() : fluid.getAmount() / 2L;
```

物品版 `AEItemConfigSlotWidget` 对应写法是 `stack.amount() << 1`,流体版少了翻倍。

## 修复

与物品版行为对齐,上滚 ×2、下滚 ÷2(一行改动):

```java
amt = wheelDelta > 0 ? fluid.getAmount() * 2L : fluid.getAmount() / 2L;
```

用 `* 2L` 而非 `<< 1`:`getAmount()` 返回 int,`<< 1` 按 int 运算有溢出风险,`* 2L` 先提升为 long,溢出由既有的 `amt < Integer.MAX_VALUE + 1L` 判断兜底。

## 验证

已在本地 0.5.7-beta runClient 中实测:设定流体后 Ctrl+上滚数量翻倍、Ctrl+下滚减半,均正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)