### PR TITLE
燃料电池修改“效率”及“衰减”的显示错误与歧义

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/generator/FullCellGenerator.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/generator/FullCellGenerator.java
@@ -159,7 +159,7 @@ public class FullCellGenerator extends ElectricMultiblockMachine {
         fuelEnergyPerUnit = (long) (fuelEnergyPerUnit * bonusEfficiency);
         if (fuelEnergyPerUnit == 0) return null;
         if (sensorPart != null) {
-            sensorPart.update((float) bonusEfficiency * 4.0f);
+            sensorPart.update((float) bonusEfficiency);
         }
 
         // find existing electrolytes
@@ -217,7 +217,7 @@ public class FullCellGenerator extends ElectricMultiblockMachine {
         super.customText(textList);
         if (!isGenerator) {
             textList.add(
-                    Component.translatable(FUEL_EFFICIENCY, FormattingUtil.formatNumber2Places(bonusEfficiency * 400) + "%"));
+                    Component.translatable(FUEL_EFFICIENCY, FormattingUtil.formatNumber2Places(bonusEfficiency * 100) + "%"));
             textList.add(
                     Component.translatable(EFFICIENCY_DECAY, DECIMAL_FORMAT_4F.format((1 - accumulatedEfficiencyDecay) * 100) + "%"));
         }
@@ -296,23 +296,23 @@ public class FullCellGenerator extends ElectricMultiblockMachine {
     }
 
     public record MembraneBonusInfo(
-                                    int tier,
-                                    Material membrane,
-                                    Material electrolyte,
-                                    double efficiencyBonus,
-                                    double efficiencyBonusDecayFactor,
-                                    double efficiencyBonusExpertMode,
-                                    double efficiencyBonusDecayFactorExpertMode) {
+            int tier,
+            Material membrane,
+            Material electrolyte,
+            double efficiencyBonus,
+            double efficiencyBonusDecayFactor,
+            double efficiencyBonusExpertMode,
+            double efficiencyBonusDecayFactorExpertMode) {
 
         public void getInfoComponents(List<Component> components) {
             components.add(Component.translatable(MEMBRANE_TIER, Component.literal(String.valueOf(tier)).withStyle(ChatFormatting.AQUA)).withStyle(ChatFormatting.GRAY));
             components.add(Component.translatable(DISCHARGE_ELECTROLYTE, electrolyte.getLocalizedName().withStyle(ChatFormatting.YELLOW)).withStyle(ChatFormatting.GRAY));
-            components.add(Component.translatable(ABSORPTION_EFFICIENCY, Component.literal(FormattingUtil.formatNumber2Places(efficiencyBonus * 400) + "%").withStyle(ChatFormatting.GREEN)).withStyle(ChatFormatting.GRAY));
+            components.add(Component.translatable(ABSORPTION_EFFICIENCY, Component.literal(FormattingUtil.formatNumber2Places(GTOCore.isExpert() ? efficiencyBonusExpertMode * 100 : efficiencyBonus * 100) + "%").withStyle(ChatFormatting.GREEN)).withStyle(ChatFormatting.GRAY));
             if (!GTOCore.isEasy()) {
-                if (efficiencyBonusDecayFactor == 1.0d) {
+                if ((GTOCore.isExpert() ? efficiencyBonusDecayFactorExpertMode : efficiencyBonusDecayFactor) == 1.0d) {
                     components.add(Component.translatable(ABSORPTION_EFFICIENCY_NO_DECAY).withStyle(ChatFormatting.GRAY));
                 } else {
-                    components.add(Component.translatable(ABSORPTION_EFFICIENCY_DECAY, Component.literal("x" + DECIMAL_FORMAT_4F.format(efficiencyBonusDecayFactor)).withStyle(ChatFormatting.RED)).withStyle(ChatFormatting.GRAY));
+                    components.add(Component.translatable(ABSORPTION_EFFICIENCY_DECAY, Component.literal("x" + DECIMAL_FORMAT_4F.format(GTOCore.isExpert() ? efficiencyBonusDecayFactorExpertMode : efficiencyBonusDecayFactor)).withStyle(ChatFormatting.RED)).withStyle(ChatFormatting.GRAY));
                 }
             }
         }

--- a/src/main/java/com/gtocore/common/machine/multiblock/generator/FullCellGenerator.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/generator/FullCellGenerator.java
@@ -296,13 +296,13 @@ public class FullCellGenerator extends ElectricMultiblockMachine {
     }
 
     public record MembraneBonusInfo(
-            int tier,
-            Material membrane,
-            Material electrolyte,
-            double efficiencyBonus,
-            double efficiencyBonusDecayFactor,
-            double efficiencyBonusExpertMode,
-            double efficiencyBonusDecayFactorExpertMode) {
+                                    int tier,
+                                    Material membrane,
+                                    Material electrolyte,
+                                    double efficiencyBonus,
+                                    double efficiencyBonusDecayFactor,
+                                    double efficiencyBonusExpertMode,
+                                    double efficiencyBonusDecayFactorExpertMode) {
 
         public void getInfoComponents(List<Component> components) {
             components.add(Component.translatable(MEMBRANE_TIER, Component.literal(String.valueOf(tier)).withStyle(ChatFormatting.AQUA)).withStyle(ChatFormatting.GRAY));


### PR DESCRIPTION
## 描述
1) 燃料电池的吸收模式效率显示目前容易产生误解。目前，在EMI中，燃料电池吸收模式的“可转换的基础能量”已经被乘上了一个倍率4.0（这个倍率是相较于普通的化学能发电机的，以火箭燃料偏二甲肼-四氧化二氮为例，在小火箭引擎的EMI中它显示的是81920EU/10mB，但在燃料电池的EMI中已经显示为了327680EU/10mB），在此基础上，膜电极的“吸收模式效率乘数”在显示上又被乘了一个倍率4.0，导致玩家会计算出327680*4EU/10mB的错误结果，因为这第二个4倍在实际运行中是不生效的。因此，有两个调整方案：
①去掉膜电极的显示倍率4.0，同时燃料电池主方块UI内的燃料效率乘数显示也会改变。此项改动是一个不兼容改动，见下方说明。
②去掉EMI“可转换的基础能量”项的倍率4.0，将倍率归入膜电极中。
在代码层面上，目前的燃料电池的计算逻辑更接近于①，因此本PR暂时采用方案①。
此调整仅为显示调整，不会影响燃料电池的实际产能。


2) 修复了一个问题：tooltip显示的膜电极的效率与衰减值不会随GTO难度变化。
<img width="1785" height="1095" alt="image" src="https://github.com/user-attachments/assets/22e9baae-bcc2-4f1d-8e09-d24b202bad98" />
<img width="1200" height="355" alt="image" src="https://github.com/user-attachments/assets/813a06ca-3e5d-402e-be0f-208c0b472f0d" />

## 不兼容改动
因为此改动，燃料电池吸收模式下离子活度传感器的输出现在会发生改变。一般情况下，将其设置的最小最大值等比例缩放至原来的25%即可恢复功能。
## Related
https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1752
