### PR TITLE
fix: ME能源塔

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
@@ -196,6 +196,11 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
     }
 
     @Override
+    public int getPriority() {
+        return 1 << 30;
+    }
+
+    @Override
     public double extractAEPower(double amt, Actionable mode, PowerMultiplier multiplier) {
         return multiplier.divide(this.extractAEPower(multiplier.multiply(amt), mode));
     }

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
@@ -3,35 +3,119 @@ package com.gtocore.common.machine.multiblock.part.ae;
 import com.gtocore.common.data.GTORecipeDataKeys;
 
 import com.gtolib.api.machine.multiblock.TierCasingMultiblockMachine;
-import com.gtolib.utils.MathUtil;
 
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.recipe.handler.IO;
 import com.gregtechceu.gtceu.config.ConfigHolder;
+
+import net.minecraft.server.TickTask;
+import net.minecraft.server.level.ServerLevel;
 
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.config.PowerUnits;
 import appeng.api.networking.energy.IAEPowerStorage;
+import appeng.api.networking.energy.IEnergyService;
 import appeng.api.networking.events.GridPowerStorageStateChanged;
+import appeng.me.service.EnergyService;
 
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 import org.jetbrains.annotations.NotNull;
 
-import static java.lang.Math.min;
+import java.lang.reflect.Field;
 
 public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPowerStorage {
 
-    private double ratio = ConfigHolder.INSTANCE.compat.energy.euToFeRatio;
+    /**
+     * AE2 {@link EnergyService} 的 providerPowerSum 字段。它只在节点 addNode/removeNode 时更新，
+     * 之后本仓容量变化不会自动刷新，这里通过反射直接读写该字段按差值修正缓存的容量。
+     */
+    private static final Field PROVIDER_POWER_SUM_FIELD;
+
+    static {
+        Field field = null;
+        try {
+            field = EnergyService.class.getDeclaredField("providerPowerSum");
+            field.setAccessible(true);
+        } catch (Exception ignored) {}
+        PROVIDER_POWER_SUM_FIELD = field;
+    }
+
     private TierCasingMultiblockMachine controller = null;
+
+    private double ratio = 1;
+
+    private boolean powerNotifyQueued = false;
+
+    private TickableSubscription tickSubs = null;
+
+    private double maxPower = 0;
 
     public MEEnergyAccessPartMachine(MetaMachineBlockEntity holder) {
         super(holder, IO.NONE);
         this.getMainNode().addService(IAEPowerStorage.class, this);
+    }
+
+    public long getEnergyCapacity() {
+        if (isInValid() || controller == null) return 0;
+        return controller.getEnergyContainer().getEnergyCapacity();
+    }
+
+    public long getEnergyStored() {
+        if (isInValid() || controller == null) return 0;
+        return controller.getEnergyContainer().getEnergyStored();
+    }
+
+    private void updateRatio() {
+        ratio = ConfigHolder.INSTANCE.compat.energy.euToFeRatio * PowerUnits.FE.convertTo(PowerUnits.AE, 1);
+        if (controller != null) {
+            ratio *= 1 + 0.3 * controller.getCasingTier(GTORecipeDataKeys.GLASS_TIER);
+            ratio *= controller.getSubFormedAmount() + 1;
+        }
+    }
+
+    private void refreshAECapacity() {
+        final double newMaxPower = getEnergyCapacity() * ratio;
+        if (maxPower == newMaxPower) return;
+        var grid = this.getMainNode().getGrid();
+        if (grid != null) {
+            try {
+                final double delta = newMaxPower - maxPower;
+                final IEnergyService energyService = grid.getEnergyService();
+                PROVIDER_POWER_SUM_FIELD.setDouble(energyService, PROVIDER_POWER_SUM_FIELD.getDouble(energyService) + delta);
+            } catch (Exception ignored) {}
+        }
+        maxPower = newMaxPower;
+    }
+
+    private void tick() {
+        if (controller == null || !this.workingEnabled) return;
+        if (controller.getEnergyContainer().getEnergyStored() <= 0) return;
+        queuePowerNotify();
+    }
+
+    private void queuePowerNotify() {
+        if (powerNotifyQueued) return;
+        if (!(getLevel() instanceof ServerLevel serverLevel)) return;
+        powerNotifyQueued = true;
+        serverLevel.getServer().tell(new TickTask(0, () -> {
+            powerNotifyQueued = false;
+            if (!isInValid() && controller != null && controller.getEnergyContainer().getEnergyStored() > 0) {
+                postEnergyEvent();
+            }
+        }));
+    }
+
+    private void postEnergyEvent() {
+        if (controller == null) return;
+        if (this.getMainNode().getGrid() != null) {
+            this.getMainNode().getGrid().postEvent(new GridPowerStorageStateChanged(this, GridPowerStorageStateChanged.PowerEventType.PROVIDE_POWER));
+        }
     }
 
     @Override
@@ -40,49 +124,49 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
         postEnergyEvent();
     }
 
-    private double EU2AE(long eu) {
-        return PowerUnits.FE.convertTo(PowerUnits.AE, eu) * ratio;
-    }
-
-    private long AE2EU(double ae) {
-        return MathUtil.saturatedCast(PowerUnits.AE.convertTo(PowerUnits.FE, ae) / ratio);
-    }
-
     @Override
     public void setWorkingEnabled(boolean workingEnabled) {
         super.setWorkingEnabled(workingEnabled);
         if (workingEnabled) postEnergyEvent();
     }
 
-    private void postEnergyEvent() {
-        if (controller == null) {
-            return;
-        }
-        this.ratio = ConfigHolder.INSTANCE.compat.energy.euToFeRatio;
-        this.ratio *= 1 + 0.3 * controller.getCasingTier(GTORecipeDataKeys.GLASS_TIER);
-        this.ratio *= controller.getSubFormedAmount() + 1;
-        if (this.getMainNode().getGrid() != null) {
-            this.getMainNode().getGrid().postEvent(new GridPowerStorageStateChanged(this, GridPowerStorageStateChanged.PowerEventType.PROVIDE_POWER));
-        }
-    }
-
     @Override
     public void removedFromController(@NotNull IMultiController controller) {
         super.removedFromController(controller);
         this.controller = null;
+        updateRatio();
+        if (getLevel() instanceof ServerLevel serverLevel) {
+            serverLevel.getServer().tell(new TickTask(0, this::refreshAECapacity));
+        }
     }
 
     @Override
     public void addedToController(@NotNull IMultiController controller) {
         super.addedToController(controller);
         this.controller = (TierCasingMultiblockMachine) controller;
+        updateRatio();
         postEnergyEvent();
+        if (getLevel() instanceof ServerLevel serverLevel) {
+            serverLevel.getServer().tell(new TickTask(0, this::refreshAECapacity));
+        }
     }
 
     @Override
     public void onLoad() {
         super.onLoad();
+        if (!isRemote()) {
+            tickSubs = subscribeServerTick(tickSubs, this::tick, 20);
+        }
         postEnergyEvent();
+    }
+
+    @Override
+    public void onUnload() {
+        super.onUnload();
+        if (tickSubs != null) {
+            tickSubs.unsubscribe();
+            tickSubs = null;
+        }
     }
 
     @Override
@@ -92,16 +176,13 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
 
     @Override
     public double getAEMaxPower() {
-        return Long.MAX_VALUE;
+        return maxPower;
     }
 
     @Override
     public double getAECurrentPower() {
-        if (controller == null) {
-            return 0;
-        }
         if (!this.workingEnabled) return 0;
-        return EU2AE(controller.getEnergyContainer().getEnergyStored());
+        return getEnergyStored() * ratio;
     }
 
     @Override
@@ -111,7 +192,7 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
 
     @Override
     public AccessRestriction getPowerFlow() {
-        return AccessRestriction.READ_WRITE;
+        return AccessRestriction.READ;
     }
 
     @Override
@@ -120,15 +201,14 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
     }
 
     private double extractAEPower(double amt, Actionable mode) {
-        if (controller == null) {
-            return 0;
-        }
-        if (!this.workingEnabled) return 0;
-        double can_extract = min(getAECurrentPower(), amt);
-        if (!mode.isSimulate()) {
-            controller.getEnergyContainer().changeEnergy(-AE2EU(can_extract));
-        }
-        return can_extract;
+        if (amt <= 0) return 0;
+        if (controller == null || !this.workingEnabled) return 0;
+        final double stored = getEnergyStored() * ratio;
+        if (stored == 0) return 0;
+        final double extracted = Math.min(stored, amt);
+        if (mode.isSimulate()) return extracted;
+        controller.getEnergyContainer().changeEnergy(-(long) Math.ceil(extracted / ratio));
+        return extracted;
     }
 
     @Override


### PR DESCRIPTION
- `refreshAECapacity` 反射直接修正 AE2 总能源上限，能够动态更新能源缓存大小
- `extractAEPower` 消耗的能源向上取整
- `queuePowerNotify` `postEnergyEvent` 事件和定时向 AE 报告可以取出能源，修复断电后不更新的问题
- `getPowerFlow` 拒绝接受 AE 充能
- `getPriority` 优先从能源塔抽取能源而不是 AE2 自身缓存（创造能源元件为例外）