### PR TITLE
feat(emi): 样板终端填充配方支持 Alt + 左击不合并相同物品

### DIFF
--- a/src/generated/resources/assets/gtocore/lang/en_us.json
+++ b/src/generated/resources/assets/gtocore/lang/en_us.json
@@ -2329,6 +2329,7 @@
   "gtocore.ae.appeng.me2in1.emi.gt_batch_encode.1": "Materials that fail to replace (e.g., the material does not exist for this item) will retain the original state of the pattern during encoding",
   "gtocore.ae.appeng.me2in1.emi.multiblock.sub": "Shift + Click: Encode base structure and this module",
   "gtocore.ae.appeng.me2in1.emi.multiblock.sub.all": "Ctrl + Click: Encode all modules up to this one",
+  "gtocore.ae.appeng.me2in1.emi.no_merge": "Alt + Click: Do not merge identical items, each recipe entry takes its own slot",
   "gtocore.ae.appeng.me2in1.encode_to.accessor": "Encode directly to the blank slots on the current page of terminal",
   "gtocore.ae.appeng.me2in1.encode_to.accessor.title": "Encode to Pattern Terminal",
   "gtocore.ae.appeng.me2in1.material_slot": "Material Slot",

--- a/src/generated/resources/assets/gtocore/lang/zh_cn.json
+++ b/src/generated/resources/assets/gtocore/lang/zh_cn.json
@@ -2457,6 +2457,7 @@
   "gtocore.ae.appeng.me2in1.emi.gt_batch_encode.1": "替换失败的材料（如该材料不存在这种物品）将在编码时保持原样板的状态",
   "gtocore.ae.appeng.me2in1.emi.multiblock.sub": "Shift + 左击：编码基础结构和当前模块",
   "gtocore.ae.appeng.me2in1.emi.multiblock.sub.all": "Ctrl + 左击：编码到当前模块为止的全部结构",
+  "gtocore.ae.appeng.me2in1.emi.no_merge": "Alt + 左击：配方中相同的物品不合并，每项各占一个槽位",
   "gtocore.ae.appeng.me2in1.encode_to.accessor": "直接编码到当前页面中的空白部分",
   "gtocore.ae.appeng.me2in1.encode_to.accessor.title": "编码到样板管理终端",
   "gtocore.ae.appeng.me2in1.material_slot": "材料槽",

--- a/src/generated/resources/assets/gtocore/lang/zh_tw.json
+++ b/src/generated/resources/assets/gtocore/lang/zh_tw.json
@@ -2457,6 +2457,7 @@
   "gtocore.ae.appeng.me2in1.emi.gt_batch_encode.1": "替換失敗的材料（如該材料不存在這種物品）將在編碼時保持原樣板的狀態",
   "gtocore.ae.appeng.me2in1.emi.multiblock.sub": "Shift + 左擊：編碼基礎結構和當前模塊",
   "gtocore.ae.appeng.me2in1.emi.multiblock.sub.all": "Ctrl + 左擊：編碼到當前模塊為止的全部結構",
+  "gtocore.ae.appeng.me2in1.emi.no_merge": "Alt + 左擊：配方中相同的物品不合併，每項各佔一個槽位",
   "gtocore.ae.appeng.me2in1.encode_to.accessor": "直接編碼到當前頁面中的空白部分",
   "gtocore.ae.appeng.me2in1.encode_to.accessor.title": "編碼到樣板管理終端",
   "gtocore.ae.appeng.me2in1.material_slot": "材料槽",

--- a/src/main/java/com/gtocore/data/lang/LangHandler.java
+++ b/src/main/java/com/gtocore/data/lang/LangHandler.java
@@ -405,6 +405,7 @@ public final class LangHandler {
         addCNEN("gtocore.ae.appeng.me2in1.emi.catalyst.virtual", "Ctrl + 左击：将催化剂（虚拟物品）填充至样板", "Ctrl + Click: Encode catalysts as virtual items");
         addCNEN("gtocore.ae.appeng.me2in1.emi.multiblock.sub", "Shift + 左击：编码基础结构和当前模块", "Shift + Click: Encode base structure and this module");
         addCNEN("gtocore.ae.appeng.me2in1.emi.multiblock.sub.all", "Ctrl + 左击：编码到当前模块为止的全部结构", "Ctrl + Click: Encode all modules up to this one");
+        addCNEN("gtocore.ae.appeng.me2in1.emi.no_merge", "Alt + 左击：配方中相同的物品不合并，每项各占一个槽位", "Alt + Click: Do not merge identical items, each recipe entry takes its own slot");
         addCNEN("gtocore.ae.appeng.me2in1.emi.gt_batch_encode", "Alt + 左击：批量编码，试图替换的材料用黄色标记", "Batch encoding is available while holding Alt, materials to be replaced are marked in yellow");
         addCNEN("gtocore.ae.appeng.me2in1.emi.gt_batch_encode.1", "替换失败的材料（如该材料不存在这种物品）将在编码时保持原样板的状态", "Materials that fail to replace (e.g., the material does not exist for this item) will retain the original state of the pattern during encoding");
         addCNEN("gtocore.ae.appeng.me2in1.save_default_rename_pattern", "保存默认重命名样板，将可以在自动填充时使用！", "Save the default renaming pattern, which can be used for auto-filling!");

--- a/src/main/java/com/gtocore/integration/emi/GTAe2PatternTerminalHandler.java
+++ b/src/main/java/com/gtocore/integration/emi/GTAe2PatternTerminalHandler.java
@@ -6,6 +6,8 @@ import com.gtolib.api.ae2.IPatterEncodingTermMenu;
 import com.gtolib.api.recipe.RecipeBuilder;
 import com.gtolib.utils.ClientUtil;
 
+import com.gregtechceu.gtceu.utils.GTUtil;
+
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -69,6 +71,9 @@ final class GTAe2PatternTerminalHandler<T extends PatternEncodingTermMenu> imple
                 .anyMatch(ing -> isCraftable(craftableKeys, ing));
         var gatheredTooltip = anyCraftable ? TransferHelper.createEncodingTooltip(true) : new ArrayList<Component>();
         gatheredTooltip.addAll(getCatalystTooltip(recipe));
+        if (!isCrafting(recipe)) {
+            gatheredTooltip.add(Component.translatable("gtocore.ae.appeng.me2in1.emi.no_merge").withStyle(ChatFormatting.YELLOW));
+        }
         return gatheredTooltip.stream()
                 .map(Component::getVisualOrderText)
                 .map(ClientTooltipComponent::create)
@@ -142,9 +147,15 @@ final class GTAe2PatternTerminalHandler<T extends PatternEncodingTermMenu> imple
             } else {
                 ((IPatterEncodingTermMenu) menu).gtolib$addRecipe("");
             }
-            EncodingHelper.encodeProcessingRecipe(menu,
-                    GTEmiEncodingHelper.ofInputs(recipe),
-                    ofOutputs(recipe));
+            if (GTUtil.isAltDown()) {
+                GTEmiEncodingHelper.encodeProcessingRecipeWithoutMerging(menu,
+                        GTEmiEncodingHelper.ofInputs(recipe),
+                        ofOutputs(recipe));
+            } else {
+                EncodingHelper.encodeProcessingRecipe(menu,
+                        GTEmiEncodingHelper.ofInputs(recipe),
+                        ofOutputs(recipe));
+            }
         }
         if (Minecraft.getInstance().screen instanceof RecipeScreen e) {
             e.onClose();

--- a/src/main/java/com/gtocore/integration/emi/GTEmiEncodingHelper.java
+++ b/src/main/java/com/gtocore/integration/emi/GTEmiEncodingHelper.java
@@ -17,6 +17,11 @@ import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
+import appeng.integration.modules.jeirei.EncodingHelper;
+import appeng.menu.me.common.GridInventoryEntry;
+import appeng.menu.me.items.PatternEncodingTermMenu;
+import appeng.menu.slot.FakeSlot;
+import appeng.parts.encoding.EncodingMode;
 
 import com.hepdd.gtmthings.api.misc.Hatch;
 import com.hepdd.gtmthings.common.item.VirtualItemProviderBehavior;
@@ -31,11 +36,21 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class GTEmiEncodingHelper {
+
+    /**
+     * 与 {@code EncodingHelper.ENTRY_COMPARATOR} 一致，用于挑选网络中最合适的那个候选物品。
+     */
+    private static final Comparator<GridInventoryEntry> ENTRY_COMPARATOR = Comparator
+            .comparing(GridInventoryEntry::isCraftable)
+            .thenComparing(GTEmiEncodingHelper::isUndamaged)
+            .thenComparingLong(GridInventoryEntry::getStoredAmount);
 
     @Nullable
     private static GenericStack ofVirtual(EmiStack stack, long amount) {
@@ -163,5 +178,38 @@ public class GTEmiEncodingHelper {
             return !(stack.getKey() instanceof MetaMachineItem meta) || !Hatch.Set.contains(meta.getBlock());
         }
         return false;
+    }
+
+    /**
+     * 等价于 {@link EncodingHelper#encodeProcessingRecipe}，但不会把配方里相同的物品合并到同一个槽位，
+     * 配方的每一项输入（输出）各占一个槽位，超出槽位数量的部分会被丢弃。
+     */
+    public static void encodeProcessingRecipeWithoutMerging(PatternEncodingTermMenu menu,
+                                                            List<List<GenericStack>> genericIngredients,
+                                                            List<GenericStack> genericResults) {
+        menu.setMode(EncodingMode.PROCESSING);
+        Map<AEKey, Integer> ingredientPriorities = EncodingHelper.getIngredientPriorities(menu, ENTRY_COMPARATOR);
+        encodeIntoSlots(genericIngredients, ingredientPriorities, menu.getProcessingInputSlots());
+        encodeIntoSlots(genericResults.stream().map(List::of).toList(), ingredientPriorities, menu.getProcessingOutputSlots());
+    }
+
+    private static void encodeIntoSlots(List<List<GenericStack>> possibleStacksBySlot, Map<AEKey, Integer> ingredientPriorities, FakeSlot[] slots) {
+        List<GenericStack> encoded = possibleStacksBySlot.stream()
+                .filter(stacks -> !stacks.isEmpty())
+                .map(stacks -> findBestIngredient(ingredientPriorities, stacks))
+                .toList();
+        for (int i = 0; i < slots.length; i++) {
+            slots[i].setFilterTo(i < encoded.size() ? GenericStack.wrapInItemStack(encoded.get(i)) : ItemStack.EMPTY);
+        }
+    }
+
+    private static GenericStack findBestIngredient(Map<AEKey, Integer> ingredientPriorities, List<GenericStack> possibleIngredients) {
+        return possibleIngredients.stream()
+                .max(Comparator.comparingInt((GenericStack stack) -> ingredientPriorities.getOrDefault(stack.what(), Integer.MIN_VALUE)))
+                .orElseThrow();
+    }
+
+    private static Boolean isUndamaged(GridInventoryEntry entry) {
+        return !(entry.getWhat() instanceof AEItemKey itemKey) || !itemKey.isDamaged();
     }
 }


### PR DESCRIPTION
在样板编码终端上用 EMI 的填充按钮时，AE2 的 EncodingHelper 会通过
addOrMerge 把配方里 AEKey 相同的物品合并进同一个槽位，原本分开的配方项
无法保留。

新增 Alt + 左击：沿用 AE2 的候选物品优先级挑选逻辑（getIngredientPriorities 与同样的排序条件），但填槽时不做合并，配方的每一项输入/输出各占一个槽位，
超出槽位数量的部分与 AE2 原行为一致地丢弃。不按 Alt 时行为完全不变，
石切等 crafting 模式按位置填充，不受影响。