### PR TITLE
fix(ae2): 并行样板在仅够一轮时永不推送 (GregTech-Odyssey/GregTech-Odyssey#1824)

### DIFF
--- a/src/main/java/com/gtocore/api/ae2/crafting/OptimizedCraftingCpuLogic.java
+++ b/src/main/java/com/gtocore/api/ae2/crafting/OptimizedCraftingCpuLogic.java
@@ -231,6 +231,13 @@ public class OptimizedCraftingCpuLogic extends CraftingCpuLogic {
                         parallelValue = parallel;
                         tmp_details = parallelPatternDetails;
                     }
+                } else {
+                    // parallel == 1：库存恰好只够一轮。此时不需要并行副本，按单轮取料，
+                    // parallelValue 保持 1，与下方非并行分支语义一致。
+                    // 缺少此分支时 craftingContainer.value 会保持 null，被下面的
+                    // `if (craftingContainer.value == null) continue;` 每 tick 静默跳过，
+                    // 导致「材料齐备但永不推送」的死锁。
+                    craftingContainer.value = extractPatternInputs(tmp_details, inventory, job.expectedOutputs);
                 }
             } else {
                 craftingContainer.value = extractPatternInputs(tmp_details, inventory, job.expectedOutputs);


### PR DESCRIPTION
executeCrafting 中，当样板是 IParallelPatternDetails 且任务剩余轮数 > 1 时， 会先调用 getMaxParallel 计算可并行轮数：

    if (isParallel && progress.value > 1) {
        var parallel = getMaxParallel(...);
        if (parallel == 0) continue;
        if (parallel > 1) { ... craftingContainer.value = extractPatternInputs(...) ... }
        // parallel == 1 时没有分支，craftingContainer.value 保持 null
    } else {
        craftingContainer.value = extractPatternInputs(...);
    }
    if (craftingContainer.value == null) continue;

parallel == 1（库存恰好只够一轮）时两个分支都不取料，craftingContainer.value 保持 null，于是每 tick 都被静默 continue 跳过：有任务、机器在线、材料够一轮，
但执行器永不推送，整条合成链死锁且无任何日志。

本提交补上 parallel == 1 的分支：按单轮取料，parallelValue 保持 1、
tmp_details 不替换成并行副本，与下方非并行路径语义一致，
因此 cappedParallel 与 progress.value -= finalParallelValue 的记账不受影响。 parallel > 1 与 parallel == 0 的既有行为均不变。

## 触发条件

输入同时出现在输出的催化剂返还型配方必然触发，因为 AE2 按净需求备料：

- 中子反射板（#1824）：锡铁合金吃 9216 还 4608，净耗 4608/轮； 剩 2 轮时 CPU 持有 13824 = 1.5 轮份，⌊13824/9216⌋ == 1 → 踩中。
- titanium_nanotube_precursor（ElectroPlating.java）：DiethyleneGlycol 输入 96*16 = 1536、输出 72*16 = 1152，净耗 384/轮；持有量约 1536+(R-1)*384， 并行两轮需 >= 3072，故 R <= 4 时恒为 1。

小量下单 100% 复现；大任务则前面几十万轮正常，偏偏在收尾最后 2~4 轮卡死。

## 追加实测（gtocore 26.7.5-alpha）

同环境另抓到两颗 CPU 同时卡死：

    crystal_processor_mainframe x3000  剩余轮25 waitingFor=0 库存47,710,845 静止360s+
    wetware_processor x10000           剩余轮55 waitingFor=0 库存51,231,962 静止360s+

两者剩余 6 个任务构成同一条串接链，全部堵在链根 titanium_nanotube_precursor_dust：

    crystal : titanium_foil 48/16  diethyleneglycol 2896/1536  NH4HF2 5200/1600  蒸馏水 4800/1600
    wetware : titanium_foil 64/16  diethyleneglycol 2688/1536  NH4HF2 6400/1600  蒸馏水 6400/1600

没有任何一格 have < need，但 min⌊have/need⌋ == 1 而剩余轮数为 3 / 4。 供应器 prov >= 1、isBusy() 恒为 false、allocations 为空、paused 为 false， 其他成因均已排除。按配方算术逐轮模拟，补上该分支后两颗 CPU 均可跑完剩余轮数
（wetware 2688 → 2304 → 1920 → 1536）。

已通过 compileJava 与 spotlessCheck。