### PR TITLE
fix: 热力发电机中煤炭块/木炭块/焦煤块应为普通燃料的10/10/9倍热值

### DIFF
--- a/src/main/java/com/gtocore/common/recipe/RecipeTypeModify.java
+++ b/src/main/java/com/gtocore/common/recipe/RecipeTypeModify.java
@@ -137,7 +137,7 @@ public final class RecipeTypeModify {
         STEAM_BOILER_RECIPES.onRecipeBuild((builder) -> {
             THERMAL_GENERATOR_FUELS.copyFrom(builder)
                     .EUt(-8)
-                    .duration((int) Math.sqrt(builder.getDuration()))
+                    .duration(builder.getDuration() / 16)
                     .save();
 
             MANA_GARDEN_FUEL.copyFrom(builder)


### PR DESCRIPTION
https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1829

sqrt()破坏了10倍/9倍的线性关系。
基于此修改，热力发电机得到了一定程度的增强，虽然它看起来还是不太划算。
一些常用的燃料现在如下（不计发电机效率）：
木棍：2.50秒，共400EU
煤炭：40秒，共6400EU
煤炭块：400秒，共64000EU
焦煤：80秒，共12800EU